### PR TITLE
More efficient frontier unvisited line structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## HEAD (unreleased)
 
-- Replace some references in tests with foobar style code (https://github.com/zombocom/dead_end/pull/38)
+- Fix bug where empty lines were interpreted to have a zero indentation (https://github.com/zombocom/dead_end/pull/39)
 
 ## 1.0.1
 

--- a/lib/dead_end/code_block.rb
+++ b/lib/dead_end/code_block.rb
@@ -17,10 +17,12 @@ module DeadEnd
   #
   #
   class CodeBlock
+    UNSET = Object.new.freeze
     attr_reader :lines
 
     def initialize(lines: [])
       @lines = Array(lines)
+      @valid = UNSET
     end
 
     def visible_lines
@@ -68,7 +70,8 @@ module DeadEnd
     end
 
     def valid?
-      DeadEnd.valid?(self.to_s)
+      return @valid if @valid != UNSET
+      @valid = DeadEnd.valid?(self.to_s)
     end
 
     def to_s

--- a/lib/dead_end/code_line.rb
+++ b/lib/dead_end/code_line.rb
@@ -36,9 +36,14 @@ module DeadEnd
     def initialize(line: , index:)
       @original_line = line.freeze
       @line = @original_line
-      @empty = line.strip.empty?
+      if line.strip.empty?
+        @empty = true
+        @indent = 0
+      else
+        @empty = false
+        @indent = SpaceCount.indent(line)
+      end
       @index = index
-      @indent = SpaceCount.indent(line)
       @status = nil # valid, invalid, unknown
       @invalid = false
 

--- a/lib/dead_end/code_line.rb
+++ b/lib/dead_end/code_line.rb
@@ -77,6 +77,10 @@ module DeadEnd
       @is_trailing_slash
     end
 
+    def indent_index
+      @indent_index ||= [indent, index]
+    end
+
     def <=>(b)
       self.index <=> b.index
     end

--- a/lib/dead_end/code_line.rb
+++ b/lib/dead_end/code_line.rb
@@ -92,15 +92,6 @@ module DeadEnd
       @is_end
     end
 
-    def mark_invalid
-      @invalid = true
-      self
-    end
-
-    def marked_invalid?
-      @invalid
-    end
-
     def mark_invisible
       @line = ""
       self

--- a/lib/dead_end/code_search.rb
+++ b/lib/dead_end/code_search.rb
@@ -75,7 +75,7 @@ module DeadEnd
       record(block: block, name: name)
 
       if block.valid?
-        block.lines.each(&:mark_invisible)
+        block.mark_invisible
         frontier << block
       else
         frontier << block
@@ -92,7 +92,7 @@ module DeadEnd
 
     # Parses the most indented lines into blocks that are marked
     # and added to the frontier
-    def add_invalid_blocks
+    def visit_new_blocks
       max_indent = frontier.next_indent_line&.indent
 
       while (line = frontier.next_indent_line) && (line.indent == max_indent)
@@ -145,7 +145,7 @@ module DeadEnd
         if frontier.expand?
           expand_invalid_block
         else
-          add_invalid_blocks
+          visit_new_blocks
         end
       end
 

--- a/spec/unit/code_line_spec.rb
+++ b/spec/unit/code_line_spec.rb
@@ -96,5 +96,14 @@ module DeadEnd
 
       expect(code_lines.map(&:indent)).to eq([0, 2, 4, 2, 0])
     end
+
+    it "doesn't count empty lines as having an indentation" do
+      code_lines = code_line_array(<<~EOM)
+
+
+      EOM
+
+      expect(code_lines.map(&:indent)).to eq([0, 0])
+    end
   end
 end

--- a/spec/unit/code_line_spec.rb
+++ b/spec/unit/code_line_spec.rb
@@ -41,20 +41,6 @@ module DeadEnd
       expect(line.is_kw?).to be_truthy
     end
 
-    it  "can be marked as invalid or valid" do
-      code_lines = code_line_array(<<~EOM)
-        def foo
-          Array(value) |x|
-          end
-        end
-      EOM
-
-      expect(code_lines[0].marked_invalid?).to be_falsey
-      code_lines[0].mark_invalid
-      expect(code_lines[0].marked_invalid?).to be_truthy
-
-    end
-
     it "ignores marked lines" do
       code_lines = code_line_array(<<~EOM)
         def foo

--- a/spec/unit/code_search_spec.rb
+++ b/spec/unit/code_search_spec.rb
@@ -277,7 +277,7 @@ module DeadEnd
 
         it "stacked ends 2" do
           search = CodeSearch.new(<<~EOM)
-            def lol
+            def cat
               blerg
             end
 
@@ -285,7 +285,7 @@ module DeadEnd
             end # one
             end # two
 
-            def lol
+            def dog
             end
           EOM
           search.call

--- a/spec/unit/code_search_spec.rb
+++ b/spec/unit/code_search_spec.rb
@@ -445,7 +445,7 @@ module DeadEnd
           puts 'lol'
         end
       EOM
-      search.add_invalid_blocks
+      search.visit_new_blocks
 
       expect(search.code_lines.join).to eq(<<~EOM)
         def foo


### PR DESCRIPTION
Previously we were keeping track of the lines that were not in the frontier via an @indent_hash with the keys as indentation and value as an array.

This was inefficient and caused us to constantly be sorting the keys. Instead, we can get the same information by only sorting once.

As a bonus perf optimization, CodeLine#indent_index generates a key for stable sort and memoizes it so it only has to be allocated once per line.