### PR TITLE
Safer NoMethodError annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Safer NoMethodError annotation (https://github.com/zombocom/dead_end/pull/48)
+
 ## 1.1.0
 
 - Annotate NoMethodError in non-production environments (https://github.com/zombocom/dead_end/pull/46)

--- a/lib/dead_end/auto.rb
+++ b/lib/dead_end/auto.rb
@@ -62,6 +62,8 @@ end
 # we can attempt to disable this behavior in a production context.
 if !DeadEnd::IsProduction.call
   class NoMethodError
+    alias :original_to_s :to_s
+
     def to_s
       return super if DeadEnd::IsProduction.call
 
@@ -91,8 +93,9 @@ if !DeadEnd::IsProduction.call
       message << $/
       message
     rescue => e
-      puts "DeadEnd Internal error: #{e.message}"
-      puts "DeadEnd Internal backtrace: #{e.backtrace}"
+      puts "DeadEnd Internal error: #{e.original_to_s}"
+      puts "DeadEnd Internal backtrace:"
+      puts backtrace.map {|l| "    " + l }.join($/)
       super
     end
   end


### PR DESCRIPTION
Previously when a NoMethodError was raised from within the DeadEnd monkeypatch then an infinite loop would be caused by calling `e.message` since that would trigger our monkeypatch recursively.

This patch fixes the issue by aliasing the original method and explicitly using that instead. 

This behavior is also tested. So while there still might be internal errors, at least they won't result in infinite loops with no output.