### PR TITLE
Namespace method aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (unreleased)
 
+## 1.1.2
+
+- Namespace Kernel method aliases (https://github.com/zombocom/dead_end/pull/51)
+
 ## 1.1.1
 
 - Safer NoMethodError annotation (https://github.com/zombocom/dead_end/pull/48)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dead_end (1.1.1)
+    dead_end (1.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/dead_end/auto.rb
+++ b/lib/dead_end/auto.rb
@@ -5,27 +5,27 @@ require_relative "../dead_end/internals"
 # Monkey patch kernel to ensure that all `require` calls call the same
 # method
 module Kernel
-  alias_method :original_require, :require
-  alias_method :original_require_relative, :require_relative
-  alias_method :original_load, :load
+  alias_method :dead_end_original_require, :require
+  alias_method :dead_end_original_require_relative, :require_relative
+  alias_method :dead_end_original_load, :load
 
   def load(file, wrap = false)
-    original_load(file)
+    dead_end_original_load(file)
   rescue SyntaxError => e
     DeadEnd.handle_error(e)
   end
 
   def require(file)
-    original_require(file)
+    dead_end_original_require(file)
   rescue SyntaxError => e
     DeadEnd.handle_error(e)
   end
 
   def require_relative(file)
     if Pathname.new(file).absolute?
-      original_require file
+      dead_end_original_require file
     else
-      original_require File.expand_path("../#{file}", caller_locations(1, 1)[0].absolute_path)
+      dead_end_original_require File.expand_path("../#{file}", caller_locations(1, 1)[0].absolute_path)
     end
   rescue SyntaxError => e
     DeadEnd.handle_error(e)
@@ -62,7 +62,7 @@ end
 # we can attempt to disable this behavior in a production context.
 if !DeadEnd::IsProduction.call
   class NoMethodError
-    alias :original_to_s :to_s
+    alias :dead_end_original_to_s :to_s
 
     def to_s
       return super if DeadEnd::IsProduction.call
@@ -93,7 +93,7 @@ if !DeadEnd::IsProduction.call
       message << $/
       message
     rescue => e
-      puts "DeadEnd Internal error: #{e.original_to_s}"
+      puts "DeadEnd Internal error: #{e.dead_end_original_to_s}"
       puts "DeadEnd Internal backtrace:"
       puts backtrace.map {|l| "    " + l }.join($/)
       super

--- a/lib/dead_end/version.rb
+++ b/lib/dead_end/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeadEnd
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end


### PR DESCRIPTION
There's a conflict when another gem has a monekypatch method named `original_require`. By adding a namespace we should ensure that there no conflict.