### PR TITLE
Do not include demo gif in the built gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Avoid including demo gif in built gem (https://github.com/zombocom/dead_end/pull/53)
+
 ## 1.1.3
 
 - Add compatibility with zeitwerk (https://github.com/zombocom/dead_end/pull/52)

--- a/dead_end.gemspec
+++ b/dead_end.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|assets)/}) }
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
Hey @schneems,

I noticed the gem includes the demo gif, which increases the gem size by ~50 kb. This change makes it so future versions avoid including files under that directory.