### PR TITLE
[changelog skip] Added missing backtick on 'unmatched unknown detected'

### DIFF
--- a/lib/dead_end/display_invalid_blocks.rb
+++ b/lib/dead_end/display_invalid_blocks.rb
@@ -82,7 +82,7 @@ module DeadEnd
             closed: `{ }`.
           EOM
         else
-          "DeadEnd: Unmatched #{@invalid_obj.unmatched_symbol}` detected"
+          "DeadEnd: Unmatched `#{@invalid_obj.unmatched_symbol}` detected"
         end
       end
 

--- a/lib/dead_end/who_dis_syntax_error.rb
+++ b/lib/dead_end/who_dis_syntax_error.rb
@@ -45,19 +45,20 @@ module DeadEnd
       @error = msg
       @unmatched_symbol = :unknown
 
-      if @error.match?(/unexpected end-of-input/)
+      case @error
+      when /unexpected end-of-input/
         @error_symbol = :missing_end
-      elsif @error.match?(/expecting end-of-input/)
+      when /expecting end-of-input/
         @error_symbol = :unmatched_syntax
         @unmatched_symbol = :end
-      elsif @error.match?(/unexpected `end'/) ||  # Ruby 2.7 & 3.0
-          @error.match?(/unexpected end,/) ||     # Ruby 2.6
-          @error.match?(/unexpected keyword_end/) # Ruby 2.5
-
-        @error_symbol = :unmatched_syntax
+      when /unexpected `end'/,      # Ruby 2.7 and 3.0
+           /unexpected end/,        # Ruby 2.6
+           /unexpected keyword_end/i # Ruby 2.5
 
         match = @error.match(/expecting '(?<unmatched_symbol>.*)'/)
         @unmatched_symbol = match[:unmatched_symbol].to_sym if match
+
+        @error_symbol = :unmatched_syntax
       else
         @error_symbol = :unknown
       end

--- a/spec/unit/display_invalid_blocks_spec.rb
+++ b/spec/unit/display_invalid_blocks_spec.rb
@@ -51,6 +51,24 @@ module DeadEnd
       expect(display.banner).to include("DeadEnd: Unmatched `end` detected")
     end
 
+    it "Unmatched unknown banner" do
+      source = <<~EOM
+        class Cat
+          def meow
+            1 *
+          end
+        end
+      EOM
+      code_lines = code_line_array(source)
+
+      display = DisplayInvalidBlocks.new(
+        code_lines: code_lines,
+        blocks: CodeBlock.new(lines: code_lines),
+        invalid_obj: WhoDisSyntaxError.new(source),
+      )
+      expect(display.banner).to include("DeadEnd: Unmatched `unknown` detected")
+    end
+
     it "missing end banner" do
       source = <<~EOM
         class Cat


### PR DESCRIPTION
Adds a missing backtick on `unknown` in the invalid block banner.