### PR TITLE
Parse error once and not twice if there's more than one available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Parse error once and not twice if there's more than one available (https://github.com/zombocom/dead_end/pull/57)
+
 ## 1.1.4
 
 - Avoid including demo gif in built gem (https://github.com/zombocom/dead_end/pull/53)

--- a/lib/dead_end/who_dis_syntax_error.rb
+++ b/lib/dead_end/who_dis_syntax_error.rb
@@ -42,6 +42,8 @@ module DeadEnd
     end
 
     def on_parse_error(msg)
+      return if @error_symbol && @unmatched_symbol
+
       @error = msg
       @unmatched_symbol = :unknown
 

--- a/spec/unit/who_dis_syntax_error_spec.rb
+++ b/spec/unit/who_dis_syntax_error_spec.rb
@@ -4,7 +4,7 @@ require_relative "../spec_helper.rb"
 
 module DeadEnd
   RSpec.describe WhoDisSyntaxError do
-    it  "determines the type of syntax error" do
+    it "determines the type of syntax error to be an unmatched end" do
       expect(
         WhoDisSyntaxError.new("def foo;").call.error_symbol
       ).to eq(:missing_end)
@@ -18,7 +18,7 @@ module DeadEnd
       ).to eq(:end)
     end
 
-    it "" do
+    it "determines the type of syntax error to be an unmatched pipe" do
       source = <<~EOM
         class Blerg
           Foo.call do |a
@@ -37,6 +37,29 @@ module DeadEnd
       expect(
         DeadEnd.invalid_type(source).unmatched_symbol
       ).to eq(:|)
+    end
+
+    it "determines the type of syntax error to be an unmatched bracket" do
+      source = <<~EOM
+        module Hey
+          class Foo
+            def initialize
+              [1,2,3
+            end
+
+            def call
+            end
+          end
+        end
+      EOM
+
+      expect(
+        DeadEnd.invalid_type(source).error_symbol
+      ).to eq(:unmatched_syntax)
+
+      expect(
+        DeadEnd.invalid_type(source).unmatched_symbol
+      ).to eq(:"]")
     end
   end
 end


### PR DESCRIPTION
If a Ruby stacktrace includes two syntax errors, like below:

```
➜  dead_end git:(main) ✗ ruby dog.rb
dog.rb:5: syntax error, unexpected `end', expecting ']'
    end
dog.rb:10: syntax error, unexpected end-of-input, expecting `end'
```

We should parse only the first time we encounter errors, and not the second
time. If we know the type of error and unmatched symbol, we shouldn't need to
check those again.