### PR TITLE
Consider if syntax error caused an unexpected variable instead of end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (unreleased)
 
+- Consider if syntax error caused an unexpected variable instead of end (https://github.com/zombocom/dead_end/pull/58)
+
+## 1.1.5
+
 - Parse error once and not twice if there's more than one available (https://github.com/zombocom/dead_end/pull/57)
 
 ## 1.1.4

--- a/lib/dead_end/who_dis_syntax_error.rb
+++ b/lib/dead_end/who_dis_syntax_error.rb
@@ -53,9 +53,11 @@ module DeadEnd
       when /expecting end-of-input/
         @error_symbol = :unmatched_syntax
         @unmatched_symbol = :end
-      when /unexpected `end'/,      # Ruby 2.7 and 3.0
-           /unexpected end/,        # Ruby 2.6
-           /unexpected keyword_end/i # Ruby 2.5
+      when /unexpected `end'/,          # Ruby 2.7 and 3.0
+           /unexpected local variable/, #
+           /unexpected end/,            # Ruby 2.6
+           /unexpected tIDENTIFIER/,    #
+           /unexpected keyword_end/i    # Ruby 2.5
 
         match = @error.match(/expecting '(?<unmatched_symbol>.*)'/)
         @unmatched_symbol = match[:unmatched_symbol].to_sym if match

--- a/lib/dead_end/who_dis_syntax_error.rb
+++ b/lib/dead_end/who_dis_syntax_error.rb
@@ -51,17 +51,12 @@ module DeadEnd
       when /unexpected end-of-input/
         @error_symbol = :missing_end
       when /expecting end-of-input/
-        @error_symbol = :unmatched_syntax
         @unmatched_symbol = :end
-      when /unexpected `end'/,          # Ruby 2.7 and 3.0
-           /unexpected local variable/, #
-           /unexpected end/,            # Ruby 2.6
-           /unexpected tIDENTIFIER/,    #
-           /unexpected keyword_end/i    # Ruby 2.5
-
-        match = @error.match(/expecting '(?<unmatched_symbol>.*)'/)
-        @unmatched_symbol = match[:unmatched_symbol].to_sym if match
-
+        @error_symbol = :unmatched_syntax
+      when /unexpected .* expecting '(?<unmatched_symbol>.*)'/
+        @unmatched_symbol = $1.to_sym if $1
+        @error_symbol = :unmatched_syntax
+      when /unexpected `end'/
         @error_symbol = :unmatched_syntax
       else
         @error_symbol = :unknown

--- a/lib/dead_end/who_dis_syntax_error.rb
+++ b/lib/dead_end/who_dis_syntax_error.rb
@@ -56,7 +56,10 @@ module DeadEnd
       when /unexpected .* expecting '(?<unmatched_symbol>.*)'/
         @unmatched_symbol = $1.to_sym if $1
         @error_symbol = :unmatched_syntax
-      when /unexpected `end'/
+      when /unexpected `end'/,          # Ruby 2.7 and 3.0
+           /unexpected end/,            # Ruby 2.6
+           /unexpected keyword_end/i    # Ruby 2.5
+
         @error_symbol = :unmatched_syntax
       else
         @error_symbol = :unknown

--- a/spec/unit/who_dis_syntax_error_spec.rb
+++ b/spec/unit/who_dis_syntax_error_spec.rb
@@ -18,25 +18,45 @@ module DeadEnd
       ).to eq(:end)
     end
 
-    it "determines the type of syntax error to be an unmatched pipe" do
-      source = <<~EOM
-        class Blerg
-          Foo.call do |a
-          end # one
+    context "determines the type of syntax error to be an unmatched pipe" do
+      it "with unexpected 'end'" do
+        source = <<~EOM
+          class Blerg
+            Foo.call do |a
+            end # one
 
-          puts lol
-          class Foo
-          end # two
-        end # three
-      EOM
+            puts lol
+            class Foo
+            end # two
+          end # three
+        EOM
 
-      expect(
-        DeadEnd.invalid_type(source).error_symbol
-      ).to eq(:unmatched_syntax)
+        expect(
+          DeadEnd.invalid_type(source).error_symbol
+        ).to eq(:unmatched_syntax)
 
-      expect(
-        DeadEnd.invalid_type(source).unmatched_symbol
-      ).to eq(:|)
+        expect(
+          DeadEnd.invalid_type(source).unmatched_symbol
+        ).to eq(:|)
+      end
+
+      it "with unexpected local variable or method" do
+        source = <<~EOM
+          class Blerg
+             [].each do |a
+              puts a
+            end
+          end
+        EOM
+
+        expect(
+          DeadEnd.invalid_type(source).error_symbol
+        ).to eq(:unmatched_syntax)
+
+        expect(
+          DeadEnd.invalid_type(source).unmatched_symbol
+        ).to eq(:|)
+      end
     end
 
     it "determines the type of syntax error to be an unmatched bracket" do


### PR DESCRIPTION
Consider `tIDENTIFIER` in Ruby 2.6 and `local variable or method` in Ruby 2.7 and 3.0

`dead_end` was showing just the syntax error, but not the banner: 
```
➜   dead_end datadog.rb

file: /Users/mauro-oto/Projects/dead_end/datadog.rb
simplified:

       4  Datadog.configure do |c|
    ❯  5    ["rails", "grpc"].each do |service
    ❯ 11    end
      12  end
```

With the fix:

```
➜  dead_end datadog.rb

DeadEnd: Unmatched `|` character detected

Example:

  `do |x` should be `do |x|`

file: /Users/mauro-oto/Projects/dead_end/datadog.rb
simplified:

       4  Datadog.configure do |c|
    ❯  5    ["rails", "grpc"].each do |service
    ❯ 11    end
      12  end
```