### PR TITLE
Ensure we always use `Kernel.caller_locations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Fix sinatra support for `require_relative` (https://github.com/zombocom/dead_end/pull/63)
+
 ## 1.1.6
 
 - Consider if syntax error caused an unexpected variable instead of end (https://github.com/zombocom/dead_end/pull/58)

--- a/lib/dead_end/auto.rb
+++ b/lib/dead_end/auto.rb
@@ -27,7 +27,7 @@ module Kernel
     if Pathname.new(file).absolute?
       dead_end_original_require file
     else
-      dead_end_original_require File.expand_path("../#{file}", caller_locations(1, 1)[0].absolute_path)
+      dead_end_original_require File.expand_path("../#{file}", Kernel.caller_locations(1, 1)[0].absolute_path)
     end
   rescue SyntaxError => e
     DeadEnd.handle_error(e)


### PR DESCRIPTION
[Some popular gem][1] redefine `caller_locations`, hence if used in
that context, dead_end would throw an error.

Reproduction:

```ruby
require "sinatra/base"
require "dead_end"

class App < Sinatra::Base
  require_relative "some"
end
```

[1]: https://github.com/sinatra/sinatra/blob/5513eb3c7969dc3d15b3c704df63a3ccce9ac9cb/lib/sinatra/base.rb#L1553

---

Thanks for the project, first time contributing hence please tell me if I have done something the wrong way.

I haven't added tests, didn't know in which file I should put those. I'll do if you tell me!