### PR TITLE
[close #50] Less greedy unmatched kw capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- Output improvements via less greedy unmatched kw capture https://github.com/zombocom/dead_end/pull/73
 - Remove NoMethodError patching instead use https://github.com/ruby/error_highlight/ (https://github.com/zombocom/dead_end/pull/71)
 
 ## 1.1.7

--- a/spec/fixtures/derailed_require_tree.rb.txt
+++ b/spec/fixtures/derailed_require_tree.rb.txt
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Tree structure used to store and sort require memory costs
+# RequireTree.new('get_process_mem')
+module DerailedBenchmarks
+  class RequireTree
+    REQUIRED_BY = {}
+
+    attr_reader   :name
+    attr_writer   :cost
+    attr_accessor :parent
+
+    def initialize(name)
+      @name     = name
+      @children = {}
+      @cost = 0
+
+    def self.reset!
+      REQUIRED_BY.clear
+      if defined?(Kernel::REQUIRE_STACK)
+        Kernel::REQUIRE_STACK.clear
+
+        Kernel::REQUIRE_STACK.push(TOP_REQUIRE)
+      end
+    end
+
+    def <<(tree)
+      @children[tree.name.to_s] = tree
+      tree.parent = self
+      (REQUIRED_BY[tree.name.to_s] ||= []) << self.name
+    end
+
+    def [](name)
+      @children[name.to_s]
+    end
+
+    # Returns array of child nodes
+    def children
+      @children.values
+    end
+
+    def cost
+      @cost || 0
+    end
+
+    # Returns sorted array of child nodes from Largest to Smallest
+    def sorted_children
+      children.sort { |c1, c2| c2.cost <=> c1.cost }
+    end
+
+    def to_string
+      str = String.new("#{name}: #{cost.round(4)} MiB")
+      if parent && REQUIRED_BY[self.name.to_s]
+        names = REQUIRED_BY[self.name.to_s].uniq - [parent.name.to_s]
+        if names.any?
+          str << " (Also required by: #{ names.first(2).join(", ") }"
+          str << ", and #{names.count - 2} others" if names.count > 3
+          str << ")"
+        end
+      end
+      str
+    end
+
+    # Recursively prints all child nodes
+    def print_sorted_children(level = 0, out = STDOUT)
+      return if cost < ENV['CUT_OFF'].to_f
+      out.puts "  " * level + self.to_string
+      level += 1
+      sorted_children.each do |child|
+        child.print_sorted_children(level, out)
+      end
+    end
+  end
+end

--- a/spec/integration/improvement_regression_spec.rb
+++ b/spec/integration/improvement_regression_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper.rb"
+
+module DeadEnd
+  RSpec.describe "Library only integration to test regressions and improvements" do
+    it "handles derailed output issues/50" do
+      source = fixtures_dir.join("derailed_require_tree.rb.txt").read
+
+      io = StringIO.new
+      DeadEnd.call(
+        io: io,
+        source: source,
+        filename: "none",
+      )
+
+      expect(io.string).to include(<<~'EOM'.indent(4))
+         5  module DerailedBenchmarks
+         6    class RequireTree
+         7      REQUIRED_BY = {}
+         9      attr_reader   :name
+        10      attr_writer   :cost
+        11      attr_accessor :parent
+      ❯ 13      def initialize(name)
+      ❯ 18      def self.reset!
+      ❯ 25      end
+        73    end
+        74  end
+        EOM
+    end
+  end
+end

--- a/spec/unit/capture_code_context_spec.rb
+++ b/spec/unit/capture_code_context_spec.rb
@@ -7,7 +7,6 @@ module DeadEnd
     it "doesn't capture trailing if or unless" do
       source = <<~'EOM'
         def call
-
           # try do
 
             @options = CommandLineParser.new.parse


### PR DESCRIPTION
Described in https://github.com/zombocom/dead_end/issues/32 we are capturing the correct code blocks, however if the problem is mis-matched keyword, then the internals of the block are incorrectly hidden.

Code was added to work backwards and show that extra mis-matched keyword, unfortunately it grabbed more and caused a less-than-ideal output:

Before:

```
$ dead_end spec/fixtures/derailed_require_tree.rb.txt

DeadEnd: Missing `end` detected

This code has a missing `end`. Ensure that all
syntax keywords (`def`, `do`, etc.) have a matching `end`.

file: /Users/rschneeman/Documents/projects/dead_end/spec/fixtures/derailed_require_tree.rb.txt
simplified:

       5  module DerailedBenchmarks
       6    class RequireTree
       7      REQUIRED_BY = {}
       9      attr_reader   :name
      10      attr_writer   :cost
      11      attr_accessor :parent
    ❯ 13      def initialize(name)
    ❯ 27      def <<(tree)
    ❯ 31      end
    ❯ 33      def [](name)
    ❯ 35      end
    ❯ 38      def children
    ❯ 40      end
    ❯ 42      def cost
    ❯ 44      end
    ❯ 47      def sorted_children
    ❯ 49      end
      73    end
      74  end
```

Instead of digging into the problem with the existing code, I re-wrote it from scratch. I've frankly got no idea why it was broken previously, but the prior code didn't make much sense. This new version is much simpler and with added comments, fairly straightforward.

After:

```
$ ./exe/dead_end spec/fixtures/derailed_require_tree.rb.txt

DeadEnd: Missing `end` detected

This code has a missing `end`. Ensure that all
syntax keywords (`def`, `do`, etc.) have a matching `end`.

file: /Users/rschneeman/Documents/projects/dead_end/spec/fixtures/derailed_require_tree.rb.txt
simplified:

       5  module DerailedBenchmarks
       6    class RequireTree
       7      REQUIRED_BY = {}
       9      attr_reader   :name
      10      attr_writer   :cost
      11      attr_accessor :parent
    ❯ 13      def initialize(name)
    ❯ 18      def self.reset!
    ❯ 25      end
      73    end
      74  end

```