### PR TITLE
[close #75] Support endless method definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- Support "endless" oneline method definitions for Ruby 3+ (https://github.com/zombocom/dead_end/pull/80)
 - Reduce timeout to 1 second (https://github.com/zombocom/dead_end/pull/79)
 - Logically consecutive lines (such as chained methods are now joined) (https://github.com/zombocom/dead_end/pull/78)
 - Output improvement for cases where the only line is an single `end` (https://github.com/zombocom/dead_end/pull/78)

--- a/spec/unit/code_line_spec.rb
+++ b/spec/unit/code_line_spec.rb
@@ -4,6 +4,17 @@ require_relative "../spec_helper"
 
 module DeadEnd
   RSpec.describe CodeLine do
+    it "supports endless method definitions" do
+      skip("Unsupported ruby version") unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3")
+
+      line = CodeLine.from_source(<<~'EOM').first
+        def square(x) = x * x
+      EOM
+
+      expect(line.is_kw?).to be_falsey
+      expect(line.is_end?).to be_falsey
+    end
+
     it "retains original line value, after being marked invisible" do
       line = CodeLine.from_source(<<~'EOM').first
         puts "lol"


### PR DESCRIPTION
When there is an "endless" method definition, we don't want to count it as having a keyword, otherwise when we try to expand it will search for a matching `end` an possibly introduce a problem in the search.

To detect this case I use the same logic introduced in https://github.com/ruby/irb/commit/826ae909c9c93a2ddca6f9cfcd9c94dbf53d44ab

For reference here are lex of a regular method definition (first line only) and then an "endless" definition:


```
irb(main):015:0> Ripper.lex("def square(x)")
=>
[[[1, 0], :on_kw, "def", FNAME],
 [[1, 3], :on_sp, " ", FNAME],
 [[1, 4], :on_ident, "square", ENDFN],
 [[1, 10], :on_lparen, "(", BEG|LABEL],
 [[1, 11], :on_ident, "x", ARG],
 [[1, 12], :on_rparen, ")", ENDFN]]
irb(main):016:0> Ripper.lex("def square(x) = x * x")
=>
[[[1, 0], :on_kw, "def", FNAME],
 [[1, 3], :on_sp, " ", FNAME],
 [[1, 4], :on_ident, "square", ENDFN],
 [[1, 10], :on_lparen, "(", BEG|LABEL],
 [[1, 11], :on_ident, "x", ARG],
 [[1, 12], :on_rparen, ")", ENDFN],
 [[1, 13], :on_sp, " ", BEG],
 [[1, 14], :on_op, "=", BEG],
 [[1, 15], :on_sp, " ", BEG],
 [[1, 16], :on_ident, "x", END|LABEL],
 [[1, 17], :on_sp, " ", END|LABEL],
 [[1, 18], :on_op, "*", BEG],
 [[1, 19], :on_sp, " ", BEG],
 [[1, 20], :on_ident, "x", END|LABEL]]
```

The detection uses a state machine. It knows when it sees an `ENDFN` state that a function is being defined, but it's not known if it's a "regular" function or not. If the `ENDFN` is followed by a `BEG` with a token of `=` and then a `END` then it's assumed to be a full "oneliner" AKA "endless" method definition.