### PR TITLE
Return non-zero status code on exceptions found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- CLI returns non-zero exit code when syntax error is found (https://github.com/zombocom/dead_end/pull/86)
 - Let -v respond with gem version instead of 'unknown' (https://github.com/zombocom/dead_end/pull/82)
 
 ## 2.0.0

--- a/exe/dead_end
+++ b/exe/dead_end
@@ -64,9 +64,15 @@ options[:record_dir] = "tmp" if ENV["DEBUG"]
 
 warn "Record dir: #{options[:record_dir]}" if options[:record_dir]
 
-DeadEnd.call(
+display = DeadEnd.call(
   source: file.read,
   filename: file.expand_path,
   terminal: options[:terminal],
   record_dir: options[:record_dir]
 )
+
+if display.document_ok?
+  exit(0)
+else
+  exit(1)
+end

--- a/lib/dead_end/display_invalid_blocks.rb
+++ b/lib/dead_end/display_invalid_blocks.rb
@@ -21,11 +21,15 @@ module DeadEnd
       @invalid_obj = invalid_obj
     end
 
+    def document_ok?
+      @blocks.none? { |b| !b.hidden? }
+    end
+
     def call
-      if @blocks.any? { |b| !b.hidden? }
-        found_invalid_blocks
-      else
+      if document_ok?
         @io.puts "Syntax OK"
+      else
+        found_invalid_blocks
       end
       self
     end

--- a/spec/integration/exe_cli_spec.rb
+++ b/spec/integration/exe_cli_spec.rb
@@ -9,7 +9,7 @@ module DeadEnd
     end
 
     def exe(cmd)
-      out = run!("#{exe_path} #{cmd}")
+      out = run!("#{exe_path} #{cmd}", raise_on_nonzero_exit: false)
       puts out if ENV["DEBUG"]
       out
     end
@@ -18,6 +18,7 @@ module DeadEnd
       ruby_file = exe_path
       out = exe(ruby_file)
       expect(out.strip).to include("Syntax OK")
+      expect($?.success?).to be_truthy
     end
 
     it "parses invalid code" do
@@ -26,6 +27,8 @@ module DeadEnd
 
       expect(out.strip).to include("Missing `end` detected")
       expect(out.strip).to include("❯ 36      def filename")
+
+      expect($?.success?).to be_falsey
     end
 
     it "handles heredocs" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,9 +37,9 @@ def code_line_array(source)
   DeadEnd::CleanDocument.new(source: source).call.lines
 end
 
-def run!(cmd)
+def run!(cmd, raise_on_nonzero_exit: true)
   out = `#{cmd} 2>&1`
-  raise "Command: #{cmd} failed: #{out}" unless $?.success?
+  raise "Command: #{cmd} failed: #{out}" if !$?.success? && raise_on_nonzero_exit
   out
 end
 


### PR DESCRIPTION
Mirroring the behavior from `ruby -wc` the command line now returns non-zero exit codes when it finds a syntax error:

```
$ ruby -wc /tmp/scratch.rb
/tmp/scratch.rb:3: syntax error, unexpected `end', expecting ']'
$ echo $?
1
```

New behavior:

```
$ ./exe/dead_end /tmp/scratch.rb

DeadEnd: Unmatched `]` detected

file: /tmp/scratch.rb
simplified:

      1  def foo
    ❯ 2    foo = [ 1,1,1
      3  end

$ echo $?
1
```

The alternative to this logic would be to return 0 for all cases unless an internal error happens. 

This change will allow the vscode extension to use an exit code rather than relying on output strings https://github.com/zombocom/dead_end-vscode/blob/2f2560a073c93015e05d0baab0bf5e2853866e0f/extension.js#L16.