### PR TITLE
Fix double output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- Fix double output bug (https://github.com/zombocom/dead_end/pull/99)
 - Fix bug causing poor results (fix #95, fix #88) ()
 - [Breaking] Remove previously deprecated `require "dead_end/fyi"` interface (https://github.com/zombocom/dead_end/pull/94)
 - DeadEnd is now fired on EVERY syntax error (https://github.com/zombocom/dead_end/pull/94)

--- a/lib/dead_end/auto.rb
+++ b/lib/dead_end/auto.rb
@@ -33,23 +33,3 @@ module Kernel
     DeadEnd.handle_error(e)
   end
 end
-
-# I honestly have no idea why this Object delegation is needed
-# I keep staring at bootsnap and it doesn't have to do this
-# is there a bug in their implementation they haven't caught or
-# am I doing something different?
-class Object
-  private
-
-  def load(path, wrap = false)
-    Kernel.load(path, wrap)
-  rescue SyntaxError => e
-    DeadEnd.handle_error(e)
-  end
-
-  def require(path)
-    Kernel.require(path)
-  rescue SyntaxError => e
-    DeadEnd.handle_error(e)
-  end
-end

--- a/spec/integration/ruby_command_line_spec.rb
+++ b/spec/integration/ruby_command_line_spec.rb
@@ -46,13 +46,13 @@ module DeadEnd
 
         require_rb = tmpdir.join("require.rb")
         require_rb.write <<~EOM
-          require_relative "./script.rb"
+          load "#{script.expand_path}"
         EOM
 
         out = `ruby -I#{lib_dir} -rdead_end #{require_rb} 2>&1`
 
         expect($?.success?).to be_falsey
-        expect(out).to include('❯  5    it "flerg"')
+        expect(out).to include('❯  5    it "flerg"').once
       end
     end
   end


### PR DESCRIPTION
When we proxy `Object.load` to `Kernel.load` we were firing `DeadEnd.handle_error` twice. Switching the test over to a `load` instead of a `require_relative` makes the error show up, which can then be asserted via adding the `once` call in rspec.

I still don't know why this code was needed in the first place.

close #97