### PR TITLE
Remove string embed suggestion

### DIFF
--- a/lib/dead_end/explain_syntax.rb
+++ b/lib/dead_end/explain_syntax.rb
@@ -80,8 +80,6 @@ module DeadEnd
         "Unmatched `end', missing keyword (`do', `def`, `if`, etc.) ?"
       when "end"
         "Unmatched keyword, missing `end' ?"
-      when "{"
-        "Unmatched `}', missing `{' or `\#{' ?"
       else
         inverse = INVERSE.fetch(miss) {
           raise "Unknown explain syntax char or key: #{miss.inspect}"


### PR DESCRIPTION
I don't believe you can make a syntax error by missing a `#{` in a string, if you do then you end up with no string embed:

```
"foo}" # => No syntax error
"#foo}" # => No syntax error
"{foo}" # => No syntax error
```

Removing this suggestion makes the error more clear. The default message will still be used which is essentially the same message minus the `#{` part.