### PR TITLE
Fix CLI edge case around position of arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Fix CLI parsing when flags come before filename (https://github.com/zombocom/dead_end/pull/102)
+
 ## 3.0.0
 
 - [Breaking] Remove previously deprecated `require "dead_end/fyi"` interface (https://github.com/zombocom/dead_end/pull/94)


### PR DESCRIPTION
The DeadEnd vscode extension relies on calling `dead_end --terminal <filename>` which was previously possible because calling `OptionParser#parse` mutates ARGV. The filename should be the first argument, but only after parsing, not before.