### PR TITLE
~1.15x faster perf w/ CodeFrontier insertion sort

### DIFF
--- a/lib/dead_end.rb
+++ b/lib/dead_end.rb
@@ -147,6 +147,7 @@ require_relative "dead_end/clean_document"
 
 require_relative "dead_end/lex_all"
 require_relative "dead_end/block_expand"
+require_relative "dead_end/insertion_sort"
 require_relative "dead_end/around_block_scan"
 require_relative "dead_end/ripper_errors"
 require_relative "dead_end/display_invalid_blocks"

--- a/lib/dead_end/insertion_sort.rb
+++ b/lib/dead_end/insertion_sort.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module DeadEnd
+  # Sort elements on insert
+  #
+  # Instead of constantly calling `sort!`, put
+  # the element where it belongs the first time
+  # around
+  #
+  # Example:
+  #
+  #   sorted = InsertionSort.new
+  #   sorted << 33
+  #   sorted << 44
+  #   sorted << 1
+  #   puts sorted.to_a
+  #   # => [1, 44, 33]
+  #
+  class InsertionSort
+    def initialize
+      @array = []
+    end
+
+    def <<(value)
+      insert_in = @array.length
+      @array.each.with_index do |existing, index|
+        case value <=> existing
+        when -1
+          insert_in = index
+          break
+        when 0
+          insert_in = index
+          break
+        when 1
+          # Keep going
+        end
+      end
+
+      @array.insert(insert_in, value)
+    end
+
+    def to_a
+      @array
+    end
+  end
+end

--- a/spec/unit/insertion_sort_spec.rb
+++ b/spec/unit/insertion_sort_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+module DeadEnd
+  class CurrentIndex
+    attr_reader :current_indent
+
+    def initialize(value)
+      @current_indent = value
+    end
+
+    def <=>(other)
+      @current_indent <=> other.current_indent
+    end
+  end
+
+  RSpec.describe CodeFrontier do
+    it "works manually" do
+      frontier = InsertionSort.new
+      frontier << CurrentIndex.new(0)
+      frontier << CurrentIndex.new(1)
+
+      expect(frontier.to_a.map(&:current_indent)).to eq([0, 1])
+
+      frontier << CurrentIndex.new(1)
+      expect(frontier.to_a.map(&:current_indent)).to eq([0, 1, 1])
+
+      frontier << CurrentIndex.new(0)
+      expect(frontier.to_a.map(&:current_indent)).to eq([0, 0, 1, 1])
+
+      frontier << CurrentIndex.new(10)
+      expect(frontier.to_a.map(&:current_indent)).to eq([0, 0, 1, 1, 10])
+
+      frontier << CurrentIndex.new(2)
+      expect(frontier.to_a.map(&:current_indent)).to eq([0, 0, 1, 1, 2, 10])
+    end
+
+    it "handles lots of values" do
+      frontier = InsertionSort.new
+      values = [18, 18, 0, 18, 0, 18, 18, 18, 18, 16, 18, 8, 18, 8, 8, 8, 16, 6, 0, 0, 16, 16, 4, 14, 14, 12, 12, 12, 10, 12, 12, 12, 12, 8, 10, 10, 8, 8, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 8, 10, 6, 6, 6, 6, 6, 6, 8, 10, 8, 8, 10, 8, 10, 8, 10, 8, 6, 8, 8, 6, 8, 6, 6, 8, 0, 8, 0, 0, 8, 8, 0, 8, 0, 8, 8, 0, 8, 8, 8, 0, 8, 0, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 8, 8, 8, 6, 8, 6, 6, 6, 6, 8, 6, 8, 6, 6, 4, 4, 6, 6, 4, 6, 4, 6, 6, 4, 6, 4, 4, 6, 6, 6, 6, 4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 6, 6, 0, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 0, 0, 6, 6, 2]
+      values.each do |v|
+        frontier << CurrentIndex.new(v)
+      end
+
+      expect(frontier.to_a.map(&:current_indent)).to eq(values.sort)
+    end
+  end
+end


### PR DESCRIPTION
## Perf difference

Before:  0.230749   0.005489   0.236238 (  0.237043)
After:  0.197075   0.005009   0.202084 (  0.202950)

## Profile code

To generate profiler output, run:

```
$ DEBUG_PERF=1 bundle exec rspec spec/integration/dead_end_spec.rb
```

See the readme for more details. You can do that against the commit before this one, and this one to see the difference.


## How I found the issue


Using `qcachegrind` on Mac, generating an output with `RubyProf::CallTreePrinter` I saw:

![](https://www.dropbox.com/s/xian4mbsgvi8xr7/Screen%20Shot%202021-11-03%20at%203.00.05%20PM.png?raw=1)

That a lot of time was being spent in `CodeFrontier#<<`, specifically in the `sort!` function and `CodeBlock<=>`.

## The fix

Because we control insertion into the array, we know that it is always sorted. We can leverage this info to place new elements in at the right location instead of placing them and then re-sorting the whole array just to place one element.

I experimented with iterating from front to back, and in reverse. I found that in my test case reverse took 7,373 comparisons while forwards took 3,130. Both represent large savings.

After changing this logic:

![](https://www.dropbox.com/s/oba4mmrmlndvkac/Screen%20Shot%202021-11-03%20at%202.58.40%20PM.png?raw=1)

You can see `sort!` no longer shows up. Instead, we're seeing `reject!` as a hotspot (though only taking up 8.4% time instead of 54% time seen in sort).

Strangely such a large bump in results only yielded ~1.15x faster overall performance change. It's still worth it, but not in line with what I expected from the tools.