### PR TITLE
Update links on readme and code of conduct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Update links on readme and code of conduct (https://github.com/zombocom/dead_end/pull/107)
+
 ## 3.0.1
 
 - Fix CLI parsing when flags come before filename (https://github.com/zombocom/dead_end/pull/102)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -68,7 +68,7 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [https://contributor-covenant.org/version/1/4][version]
+available at [https://contributor-covenant.org/version/1/4/code-of-conduct/][version]
 
 [homepage]: https://contributor-covenant.org
-[version]: https://contributor-covenant.org/version/1/4/
+[version]: https://contributor-covenant.org/version/1/4/code-of-conduct/

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ $ qcachegrind tmp/last/profile.callgrind.out.<numbers>
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/zombocom/dead_end. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/zombocom/dead_end/blob/master/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at https://github.com/zombocom/dead_end. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/zombocom/dead_end/blob/main/CODE_OF_CONDUCT.md).
 
 
 ## License
@@ -204,4 +204,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the DeadEnd project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/zombocom/dead_end/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the DeadEnd project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/zombocom/dead_end/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Links on README were not completely dead as they were redirecting to the right
place, but this fixes them. Also fixing links on the code of conduct, as it
seems to bring up the italian version for some reason instead of the english
version.