### PR TITLE
Faster unvisited_lines removal

### DIFF
--- a/lib/dead_end/code_frontier.rb
+++ b/lib/dead_end/code_frontier.rb
@@ -54,6 +54,8 @@ module DeadEnd
       @code_lines = code_lines
       @frontier = InsertionSort.new
       @unvisited_lines = @code_lines.sort_by(&:indent_index)
+      @visited_lines = {}
+
       @has_run = false
       @check_next = true
     end
@@ -128,7 +130,13 @@ module DeadEnd
     end
 
     def register_indent_block(block)
-      @unvisited_lines -= block.lines
+      block.lines.each do |line|
+        next if @visited_lines[line]
+        @visited_lines[line] = true
+
+        index = @unvisited_lines.bsearch_index { |l| line.indent_index <=> l.indent_index }
+        @unvisited_lines.delete_at(index)
+      end
       self
     end
 


### PR DESCRIPTION
Identified in the profiler as taking a long time

Before:     

![](https://www.dropbox.com/s/ssa18i1if50t550/Screen%20Shot%202021-11-10%20at%206.32.06%20PM.png?raw=1)


By removing the `Array#-` call we speed that section up by roughly double

After: 

![](https://www.dropbox.com/s/nkktxle1gvcmckt/Screen%20Shot%202021-11-10%20at%206.33.36%20PM.png?raw=1)


Before:   0.163143   0.004160   0.167303 (  0.167356)
After:    0.135444   0.003195   0.138639 (  0.138698)