### PR TITLE
Handle more ripper errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- Expand explanations coming from additional Ripper errors (https://github.com/zombocom/dead_end/pull/117)
 - Fix explanation involving shorthand syntax for literals like `%w[]` and `%Q{}` (https://github.com/zombocom/dead_end/pull/116)
 
 ## 3.0.2

--- a/lib/dead_end/ripper_errors.rb
+++ b/lib/dead_end/ripper_errors.rb
@@ -18,6 +18,12 @@ module DeadEnd
       @errors << msg
     end
 
+    alias_method :on_alias_error, :on_parse_error
+    alias_method :on_assign_error, :on_parse_error
+    alias_method :on_class_name_error, :on_parse_error
+    alias_method :on_param_error, :on_parse_error
+    alias_method :compile_error, :on_parse_error
+
     def call
       @run_once ||= begin
         @errors = []

--- a/spec/unit/explain_syntax_spec.rb
+++ b/spec/unit/explain_syntax_spec.rb
@@ -4,6 +4,19 @@ require_relative "../spec_helper"
 
 module DeadEnd
   RSpec.describe "ExplainSyntax" do
+    it "handles shorthand syntaxes with non-bracket characters" do
+      source = <<~EOM
+        %Q* lol
+      EOM
+
+      explain = ExplainSyntax.new(
+        code_lines: CodeLine.from_source(source)
+      ).call
+
+      expect(explain.missing).to eq([])
+      expect(explain.errors.join).to include("unterminated string")
+    end
+
     it "handles %w[]" do
       source = <<~EOM
         node.is_a?(Op) && %w[| ||].include?(node.value) &&


### PR DESCRIPTION
While investigating https://github.com/zombocom/dead_end/pull/116 I realized that the shorthand syntax does not have to be limited to our existing "pairs" characters that we already track. While coming up with additional test cases I realized that the existing `on_parse_error` does not emit an error for the code: `%Q* lol` (missing a `*` to close the string).

This commit adds the missing check (coming from `compile_error`) as well as several others coming from the event table:

```
irb(main):008:0> Ripper::PARSER_EVENT_TABLE.select {|(k,v)| k.to_s.end_with?("error") }.keys
=> [:alias_error, :assign_error, :class_name_error, :param_error, :irb(main):008:0> Ripper::PARSER_EVENT_TABLE.select {|(k,v)| k.to_s.end_with?("error") }.keys
=> [:alias_error, :assign_error, :class_name_error, :param_error, :parse_error]
```