### PR TITLE
Fix incorrect keyword lexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (unreleased)
 
+## 3.1.1
+
+- Fix case where Ripper lexing identified incorrect code as a keyword (https://github.com/zombocom/dead_end/pull/122)
+
 ## 3.1.0
 
 - Add support for Ruby 3.1 by updating `require_relative` logic (https://github.com/zombocom/dead_end/pull/120)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dead_end (3.1.0)
+    dead_end (3.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -62,4 +62,4 @@ DEPENDENCIES
   standard
 
 BUNDLED WITH
-   2.2.30
+   2.3.4

--- a/lib/dead_end/lex_all.rb
+++ b/lib/dead_end/lex_all.rb
@@ -25,7 +25,10 @@ module DeadEnd
         lineno = @lex.last.pos.first + 1
       end
 
-      @lex.map! { |elem| LexValue.new(elem.pos.first, elem.event, elem.tok, elem.state) }
+      last_lex = nil
+      @lex.map! { |elem|
+        last_lex = LexValue.new(elem.pos.first, elem.event, elem.tok, elem.state, last_lex)
+      }
     end
 
     def to_a

--- a/lib/dead_end/lex_value.rb
+++ b/lib/dead_end/lex_value.rb
@@ -15,19 +15,21 @@ module DeadEnd
   class LexValue
     attr_reader :line, :type, :token, :state
 
-    def initialize(line, type, token, state)
+    def initialize(line, type, token, state, last_lex = nil)
       @line = line
       @type = type
       @token = token
       @state = state
 
-      set_kw_end
+      set_kw_end(last_lex)
     end
 
-    private def set_kw_end
+    private def set_kw_end(last_lex)
       @is_end = false
       @is_kw = false
       return if type != :on_kw
+      #
+      return if last_lex && last_lex.fname? # https://github.com/ruby/ruby/commit/776759e300e4659bb7468e2b97c8c2d4359a2953
 
       case token
       when "if", "unless", "while", "until"
@@ -39,6 +41,10 @@ module DeadEnd
       when "end"
         @is_end = true
       end
+    end
+
+    def fname?
+      state.allbits?(Ripper::EXPR_FNAME)
     end
 
     def ignore_newline?

--- a/lib/dead_end/version.rb
+++ b/lib/dead_end/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeadEnd
-  VERSION = "3.1.0"
+  VERSION = "3.1.1"
 end

--- a/spec/unit/code_line_spec.rb
+++ b/spec/unit/code_line_spec.rb
@@ -4,6 +4,18 @@ require_relative "../spec_helper"
 
 module DeadEnd
   RSpec.describe CodeLine do
+    it "bug in keyword detection" do
+      lines = CodeLine.from_source(<<~'EOM')
+        def to_json(*opts)
+          {
+            type: :module,
+          }.to_json(*opts)
+        end
+      EOM
+      expect(lines.count(&:is_kw?)).to eq(1)
+      expect(lines.count(&:is_end?)).to eq(1)
+    end
+
     it "supports endless method definitions" do
       skip("Unsupported ruby version") unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3")
 


### PR DESCRIPTION
For some weird reason this line is detected as a keyword line:

```
            type: :module,
```

Though it clearly isn't. Ripper:

```
require 'ripper'

pp Ripper.lex(<<~'EOM')
  {
    type: :module,
  }
EOM
```

Produces:

```
[[[1, 0], :on_lbrace, "{", BEG|LABEL],
 [[1, 1], :on_ignored_nl, "\n", BEG|LABEL],
 [[2, 0], :on_sp, "  ", BEG|LABEL],
 [[2, 2], :on_label, "type:", ARG|LABELED],
 [[2, 7], :on_sp, " ", ARG|LABELED],
 [[2, 8], :on_symbeg, ":", FNAME],
 [[2, 9], :on_kw, "module", ENDFN],
 [[2, 15], :on_comma, ",", BEG|LABEL],
 [[2, 16], :on_ignored_nl, "\n", BEG|LABEL],
 [[3, 0], :on_rbrace, "}", END],
 [[3, 1], :on_nl, "\n", BEG],
 [[4, 0], :on_const, "EOM", CMDARG]]
```

This is the problem line:

```
 [[2, 9], :on_kw, "module", ENDFN],
```

Digging into the IRB source code they handled this case here https://github.com/ruby/ruby/commit/776759e300e4659bb7468e2b97c8c2d4359a2953. Based on the description I believe this may be a bug in the lexer, but I'm not sure how to validate it.