### PR TITLE
1.22x faster Greedy new lines

### DIFF
--- a/lib/dead_end/code_search.rb
+++ b/lib/dead_end/code_search.rb
@@ -89,25 +89,15 @@ module DeadEnd
       frontier << block
     end
 
-    # Removes the block without putting it back in the frontier
-    def sweep(block:, name:)
-      record(block: block, name: name)
-
-      block.lines.each(&:mark_invisible)
-      frontier.register_indent_block(block)
-    end
-
     # Parses the most indented lines into blocks that are marked
     # and added to the frontier
     def visit_new_blocks
       max_indent = frontier.next_indent_line&.indent
 
       while (line = frontier.next_indent_line) && (line.indent == max_indent)
-
         @parse_blocks_from_indent_line.each_neighbor_block(frontier.next_indent_line) do |block|
           record(block: block, name: "add")
 
-          block.mark_invisible if block.valid?
           push(block, name: "add")
         end
       end

--- a/lib/dead_end/parse_blocks_from_indent_line.rb
+++ b/lib/dead_end/parse_blocks_from_indent_line.rb
@@ -42,13 +42,18 @@ module DeadEnd
 
       neighbors = scan.code_block.lines
 
-      until neighbors.empty?
-        lines = [neighbors.pop]
-        while (block = CodeBlock.new(lines: lines)) && block.invalid? && neighbors.any?
-          lines.prepend neighbors.pop
-        end
+      block = CodeBlock.new(lines: neighbors)
+      if neighbors.length <= 2 || block.valid?
+        yield block
+      else
+        until neighbors.empty?
+          lines = [neighbors.pop]
+          while (block = CodeBlock.new(lines: lines)) && block.invalid? && neighbors.any?
+            lines.prepend neighbors.pop
+          end
 
-        yield block if block
+          yield block if block
+        end
       end
     end
   end


### PR DESCRIPTION
While adding new lines we can first check if ALL of them are valid. If so we can skip repeatedly calling ripper to check `CodeBlock#valid?`


Before: Finished in 1.43 seconds (files took 0.14836 seconds to load)
After:  Finished in 1.17 seconds (files took 0.15893 seconds to load)