### PR TITLE
Fix AroundBlockScan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- Fixed internal class AroundBlockScan, minor changes in outputs (https://github.com/zombocom/dead_end/pull/131)
+
 ## 3.1.1
 
 - Fix case where Ripper lexing identified incorrect code as a keyword (https://github.com/zombocom/dead_end/pull/122)

--- a/lib/dead_end/around_block_scan.rb
+++ b/lib/dead_end/around_block_scan.rb
@@ -193,6 +193,10 @@ module DeadEnd
       @code_lines[0...@orig_before_index] || []
     end
 
+    private def before_lines
+      now = @code_lines[0...before_index] || []
+    end
+
     private def after_lines
       @code_lines[after_index.next..-1] || []
     end

--- a/lib/dead_end/around_block_scan.rb
+++ b/lib/dead_end/around_block_scan.rb
@@ -87,7 +87,7 @@ module DeadEnd
       end_count = 0
       index = after_lines.take_while do |line|
         next false if stop_next
-        next true if @skip_hidden &&  line.hidden?
+        next true if @skip_hidden && line.hidden?
         next true if @skip_empty && line.empty?
 
         kw_count += 1 if line.is_kw?
@@ -198,7 +198,11 @@ module DeadEnd
     end
 
     def code_block
-      CodeBlock.new(lines: @code_lines[before_index..after_index])
+      CodeBlock.new(lines: lines)
+    end
+
+    def lines
+      @code_lines[before_index..after_index]
     end
 
     def before_index

--- a/lib/dead_end/around_block_scan.rb
+++ b/lib/dead_end/around_block_scan.rb
@@ -54,7 +54,7 @@ module DeadEnd
 
       kw_count = 0
       end_count = 0
-      @before_index = before_lines.reverse_each.take_while do |line|
+      index = before_lines.reverse_each.take_while do |line|
         next false if stop_next
         next true if @skip_array.detect { |meth| line.send(meth) }
 
@@ -67,10 +67,14 @@ module DeadEnd
         block.call(line)
       end.last&.index
 
+      if index && index < before_index
+        @before_index = index
+      end
+
       stop_next = false
       kw_count = 0
       end_count = 0
-      @after_index = after_lines.take_while do |line|
+      index = after_lines.take_while do |line|
         next false if stop_next
         next true if @skip_array.detect { |meth| line.send(meth) }
 
@@ -82,6 +86,10 @@ module DeadEnd
 
         block.call(line)
       end.last&.index
+
+      if index && index > after_index
+        @after_index = index
+      end
       self
     end
 
@@ -190,11 +198,7 @@ module DeadEnd
     end
 
     private def before_lines
-      @code_lines[0...@orig_before_index] || []
-    end
-
-    private def before_lines
-      now = @code_lines[0...before_index] || []
+      @code_lines[0...before_index] || []
     end
 
     private def after_lines

--- a/lib/dead_end/block_expand.rb
+++ b/lib/dead_end/block_expand.rb
@@ -56,7 +56,7 @@ module DeadEnd
         .skip(:hidden?)
         .stop_after_kw
         .scan_neighbors
-        .scan_while { |line| line.empty? || line.hidden? }
+        .scan_while { |line| line.empty? } # Slurp up empties
         .code_block
 
       if block.lines == expanded.lines

--- a/lib/dead_end/block_expand.rb
+++ b/lib/dead_end/block_expand.rb
@@ -36,7 +36,7 @@ module DeadEnd
     end
 
     def call(block)
-      if (next_block = expand_neighbors(block, grab_empty: true))
+      if (next_block = expand_neighbors(block))
         return next_block
       end
 
@@ -51,24 +51,18 @@ module DeadEnd
         .code_block
     end
 
-    def expand_neighbors(block, grab_empty: true)
-      scan = AroundBlockScan.new(code_lines: @code_lines, block: block)
+    def expand_neighbors(block)
+      expanded = AroundBlockScan.new(code_lines: @code_lines, block: block)
         .skip(:hidden?)
         .stop_after_kw
         .scan_neighbors
+        .scan_while { |line| line.empty? || line.hidden? }
+        .code_block
 
-      # Slurp up empties
-      if grab_empty
-        scan = AroundBlockScan.new(code_lines: @code_lines, block: scan.code_block)
-          .scan_while { |line| line.empty? || line.hidden? }
-      end
-
-      new_block = scan.code_block
-
-      if block.lines == new_block.lines
+      if block.lines == expanded.lines
         nil
       else
-        new_block
+        expanded
       end
     end
   end

--- a/lib/dead_end/block_expand.rb
+++ b/lib/dead_end/block_expand.rb
@@ -52,18 +52,23 @@ module DeadEnd
     end
 
     def expand_neighbors(block)
-      expanded = AroundBlockScan.new(code_lines: @code_lines, block: block)
+      expanded_lines = AroundBlockScan.new(code_lines: @code_lines, block: block)
         .skip(:hidden?)
         .stop_after_kw
         .scan_neighbors
         .scan_while { |line| line.empty? } # Slurp up empties
-        .code_block
+        .lines
 
-      if block.lines == expanded.lines
+      if block.lines == expanded_lines
         nil
       else
-        expanded
+        CodeBlock.new(lines: expanded_lines)
       end
+    end
+
+    # Managable rspec errors
+    def inspect
+      "#<DeadEnd::CodeBlock:0x0000123843lol >"
     end
   end
 end

--- a/spec/integration/dead_end_spec.rb
+++ b/spec/integration/dead_end_spec.rb
@@ -29,7 +29,6 @@ module DeadEnd
              6  class SyntaxTree < Ripper
            170    def self.parse(source)
            174    end
-           176    private
         ❯  754    def on_args_add(arguments, argument)
         ❯  776    class ArgsAddBlock
         ❯  810    end
@@ -119,7 +118,6 @@ module DeadEnd
            7      REQUIRED_BY = {}
            9      attr_reader   :name
           10      attr_writer   :cost
-          11      attr_accessor :parent
         ❯ 13      def initialize(name)
         ❯ 18      def self.reset!
         ❯ 25      end

--- a/spec/unit/around_block_scan_spec.rb
+++ b/spec/unit/around_block_scan_spec.rb
@@ -4,6 +4,23 @@ require_relative "../spec_helper"
 
 module DeadEnd
   RSpec.describe AroundBlockScan do
+    it "continues scan from last location even if scan is false" do
+      source = <<~'EOM'
+        print 'omg'
+        print 'lol'
+        print 'haha'
+      EOM
+      code_lines = CodeLine.from_source(source)
+      block = CodeBlock.new(lines: code_lines[1])
+      expand = AroundBlockScan.new(code_lines: code_lines, block: block)
+        .scan_neighbors
+
+      expect(expand.code_block.to_s).to eq(source)
+      expand.scan_while { |line| false }
+
+      expect(expand.code_block.to_s).to eq(source)
+    end
+
     it "scan_adjacent_indent works on first or last line" do
       source_string = <<~EOM
         def foo

--- a/spec/unit/capture_code_context_spec.rb
+++ b/spec/unit/capture_code_context_spec.rb
@@ -4,6 +4,35 @@ require_relative "../spec_helper"
 
 module DeadEnd
   RSpec.describe CaptureCodeContext do
+    it "capture_before_after_kws" do
+      source = <<~'EOM'
+        def sit
+        end
+
+        def bark
+
+        def eat
+        end
+      EOM
+
+      code_lines = CodeLine.from_source(source)
+
+      block = CodeBlock.new(lines: code_lines[0])
+
+      display = CaptureCodeContext.new(
+        blocks: [block],
+        code_lines: code_lines
+      )
+      lines = display.call
+      expect(lines.join).to eq(<<~EOM)
+        def sit
+        end
+        def bark
+        def eat
+        end
+      EOM
+    end
+
     it "handles ambiguous end" do
       source = <<~'EOM'
         def call          # 1
@@ -94,7 +123,6 @@ module DeadEnd
       expect(lines.join).to eq(<<~EOM)
         class Rexe
           VERSION = '1.5.1'
-          PROJECT_URL = 'https://github.com/keithrbennett/rexe'
           class Lookups
             def format_requires
           end


### PR DESCRIPTION
Previously we were accidentally not using the persisted @before_index and instead using the "original" before index. This commit fixes that problem and adds a test for the behavior.