### PR TITLE
Decouple Capture Context tests

### DIFF
--- a/spec/integration/dead_end_spec.rb
+++ b/spec/integration/dead_end_spec.rb
@@ -146,5 +146,66 @@ module DeadEnd
           551  end
       EOM
     end
+
+    it "rexe" do
+      lines = fixtures_dir.join("rexe.rb.txt").read.lines
+      lines.delete_at(148 - 1)
+      source = lines.join
+
+      io = StringIO.new
+      DeadEnd.call(
+        io: io,
+        source: source
+      )
+      out = io.string
+      expect(out).to include(<<~EOM)
+           16  class Rexe
+           18    VERSION = '1.5.1'
+        ❯  77    class Lookups
+        ❯ 140      def format_requires
+        ❯ 148    end
+          551  end
+      EOM
+    end
+
+    it "ambiguous end" do
+      source = <<~'EOM'
+        def call          # 0
+            print "lol"   # 1
+          end # one       # 2
+        end # two         # 3
+      EOM
+      io = StringIO.new
+      DeadEnd.call(
+        io: io,
+        source: source
+      )
+      out = io.string
+      expect(out).to include(<<~EOM)
+        ❯ 1  def call          # 0
+        ❯ 3    end # one       # 2
+        ❯ 4  end # two         # 3
+      EOM
+    end
+
+    it "simple regression" do
+      source = <<~'EOM'
+        class Dog
+          def bark
+            puts "woof"
+        end
+      EOM
+      io = StringIO.new
+      DeadEnd.call(
+        io: io,
+        source: source
+      )
+      out = io.string
+      expect(out).to include(<<~EOM)
+        ❯ 1  class Dog
+        ❯ 2    def bark
+        ❯ 4  end
+      EOM
+    end
   end
 end

--- a/spec/unit/code_search_spec.rb
+++ b/spec/unit/code_search_spec.rb
@@ -4,6 +4,37 @@ require_relative "../spec_helper"
 
 module DeadEnd
   RSpec.describe CodeSearch do
+    it "regression test ambiguous end" do
+      source = <<~'EOM'
+        def call          # 0
+            print "lol"   # 1
+          end # one       # 2
+        end # two         # 3
+      EOM
+
+      search = CodeSearch.new(source)
+      search.call
+
+      expect(search.invalid_blocks.join).to eq(<<~'EOM')
+        end # two         # 3
+      EOM
+    end
+
+    it "regression dog test" do
+      source = <<~'EOM'
+        class Dog
+          def bark
+            puts "woof"
+        end
+      EOM
+      search = CodeSearch.new(source)
+      search.call
+
+      expect(search.invalid_blocks.join).to eq(<<~'EOM')
+        class Dog
+      EOM
+    end
+
     it "handles mismatched |" do
       source = <<~EOM
         class Blerg
@@ -18,7 +49,7 @@ module DeadEnd
       search = CodeSearch.new(source)
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~EOM.indent(2))
+      expect(search.invalid_blocks.join).to eq(<<~'EOM'.indent(2))
         Foo.call do |a
         end # one
       EOM
@@ -37,7 +68,7 @@ module DeadEnd
       search = CodeSearch.new(source)
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~EOM.indent(2))
+      expect(search.invalid_blocks.join).to eq(<<~'EOM'.indent(2))
         Foo.call do {
       EOM
     end
@@ -71,7 +102,7 @@ module DeadEnd
     end
 
     it "handles no spaces between blocks" do
-      source = <<~EOM
+      source = <<~'EOM'
         context "foo bar" do
           it "bars the foo" do
             travel_to DateTime.new(2020, 10, 1, 10, 0, 0) do
@@ -91,7 +122,7 @@ module DeadEnd
     it "records debugging steps to a directory" do
       Dir.mktmpdir do |dir|
         dir = Pathname(dir)
-        search = CodeSearch.new(<<~EOM, record_dir: dir)
+        search = CodeSearch.new(<<~'EOM', record_dir: dir)
           class OH
             def hello
             def hai
@@ -112,7 +143,7 @@ module DeadEnd
     end
 
     it "def with missing end" do
-      search = CodeSearch.new(<<~EOM)
+      search = CodeSearch.new(<<~'EOM')
         class OH
           def hello
 
@@ -125,7 +156,7 @@ module DeadEnd
 
       expect(search.invalid_blocks.join.strip).to eq("def hello")
 
-      search = CodeSearch.new(<<~EOM)
+      search = CodeSearch.new(<<~'EOM')
         class OH
           def hello
 
@@ -137,7 +168,7 @@ module DeadEnd
 
       expect(search.invalid_blocks.join.strip).to eq("def hello")
 
-      search = CodeSearch.new(<<~EOM)
+      search = CodeSearch.new(<<~'EOM')
         class OH
           def hello
           def hai
@@ -146,7 +177,7 @@ module DeadEnd
       EOM
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~EOM.indent(2))
+      expect(search.invalid_blocks.join).to eq(<<~'EOM'.indent(2))
         def hello
       EOM
     end
@@ -163,13 +194,13 @@ module DeadEnd
           highlight_lines: search.invalid_blocks.flat_map(&:lines)
         ).call
 
-        expect(document).to include(<<~EOM)
+        expect(document).to include(<<~'EOM')
           ❯ 36      def filename
         EOM
       end
 
       it "Format Code blocks real world example" do
-        search = CodeSearch.new(<<~EOM)
+        search = CodeSearch.new(<<~'EOM')
           require 'rails_helper'
 
           RSpec.describe AclassNameHere, type: :worker do
@@ -210,7 +241,7 @@ module DeadEnd
           highlight_lines: search.invalid_blocks.flat_map(&:lines)
         ).call
 
-        expect(document).to include(<<~EOM)
+        expect(document).to include(<<~'EOM')
              1  require 'rails_helper'
              2
              3  RSpec.describe AclassNameHere, type: :worker do
@@ -225,32 +256,9 @@ module DeadEnd
     # For code that's not perfectly formatted, we ideally want to do our best
     # These examples represent the results that exist today, but I would like to improve upon them
     describe "needs improvement" do
-      describe "missing describe/do line" do
-        it "blerg" do
-          # code_lines = code_line_array fixtures_dir.join("this_project_extra_def.rb.txt").read
-          # block = CodeBlock.new(
-          #   lines: code_lines[31],
-          #   code_lines: code_lines
-          # )
-          # expect(block.to_s).to eq(<<~EOM.indent(8))
-          #   \#{code_with_filename}
-          # EOM
-
-          # puts    block.before_line.to_s.inspect
-          # puts    block.before_line.to_s.split(/\S/).inspect
-          # puts    block.before_line.indent
-
-          # puts    block.after_line.to_s.inspect
-          # puts    block.after_line.to_s.split(/\S/).inspect
-          # puts    block.after_line.indent
-
-          # puts block.expand_until_next_boundry
-        end
-      end
-
       describe "mis-matched-indentation" do
         it "extra space before end" do
-          search = CodeSearch.new(<<~EOM)
+          search = CodeSearch.new(<<~'EOM')
             Foo.call
               def foo
                 puts "lol"
@@ -260,14 +268,14 @@ module DeadEnd
           EOM
           search.call
 
-          expect(search.invalid_blocks.join).to eq(<<~EOM)
+          expect(search.invalid_blocks.join).to eq(<<~'EOM')
             Foo.call
             end # two
           EOM
         end
 
         it "stacked ends 2" do
-          search = CodeSearch.new(<<~EOM)
+          search = CodeSearch.new(<<~'EOM')
             def cat
               blerg
             end
@@ -281,7 +289,7 @@ module DeadEnd
           EOM
           search.call
 
-          expect(search.invalid_blocks.join).to eq(<<~EOM)
+          expect(search.invalid_blocks.join).to eq(<<~'EOM')
             Foo.call do
             end # one
             end # two
@@ -290,7 +298,7 @@ module DeadEnd
         end
 
         it "stacked ends " do
-          search = CodeSearch.new(<<~EOM)
+          search = CodeSearch.new(<<~'EOM')
             Foo.call
               def foo
                 puts "lol"
@@ -300,14 +308,14 @@ module DeadEnd
           EOM
           search.call
 
-          expect(search.invalid_blocks.join).to eq(<<~EOM)
+          expect(search.invalid_blocks.join).to eq(<<~'EOM')
             Foo.call
             end
           EOM
         end
 
         it "missing space before end" do
-          search = CodeSearch.new(<<~EOM)
+          search = CodeSearch.new(<<~'EOM')
             Foo.call
 
               def foo
@@ -319,7 +327,7 @@ module DeadEnd
           search.call
 
           # expand-1 and expand-2 seem to be broken?
-          expect(search.invalid_blocks.join).to eq(<<~EOM)
+          expect(search.invalid_blocks.join).to eq(<<~'EOM')
             Foo.call
             end
           EOM
@@ -328,7 +336,7 @@ module DeadEnd
     end
 
     it "returns syntax error in outer block without inner block" do
-      search = CodeSearch.new(<<~EOM)
+      search = CodeSearch.new(<<~'EOM')
         Foo.call
           def foo
             puts "lol"
@@ -338,27 +346,27 @@ module DeadEnd
       EOM
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~EOM)
+      expect(search.invalid_blocks.join).to eq(<<~'EOM')
         Foo.call
         end # two
       EOM
     end
 
     it "doesn't just return an empty `end`" do
-      search = CodeSearch.new(<<~EOM)
+      search = CodeSearch.new(<<~'EOM')
         Foo.call
         end
       EOM
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~EOM)
+      expect(search.invalid_blocks.join).to eq(<<~'EOM')
         Foo.call
         end
       EOM
     end
 
     it "finds multiple syntax errors" do
-      search = CodeSearch.new(<<~EOM)
+      search = CodeSearch.new(<<~'EOM')
         describe "hi" do
           Foo.call
           end
@@ -371,7 +379,7 @@ module DeadEnd
       EOM
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~EOM.indent(2))
+      expect(search.invalid_blocks.join).to eq(<<~'EOM'.indent(2))
         Foo.call
         end
         Bar.call
@@ -380,47 +388,47 @@ module DeadEnd
     end
 
     it "finds a typo def" do
-      search = CodeSearch.new(<<~EOM)
+      search = CodeSearch.new(<<~'EOM')
         defzfoo
           puts "lol"
         end
       EOM
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~EOM)
+      expect(search.invalid_blocks.join).to eq(<<~'EOM')
         defzfoo
         end
       EOM
     end
 
     it "finds a mis-matched def" do
-      search = CodeSearch.new(<<~EOM)
+      search = CodeSearch.new(<<~'EOM')
         def foo
           def blerg
         end
       EOM
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~EOM.indent(2))
+      expect(search.invalid_blocks.join).to eq(<<~'EOM'.indent(2))
         def blerg
       EOM
     end
 
     it "finds a naked end" do
-      search = CodeSearch.new(<<~EOM)
+      search = CodeSearch.new(<<~'EOM')
         def foo
           end # one
         end # two
       EOM
       search.call
 
-      expect(search.invalid_blocks.join).to eq(<<~EOM.indent(2))
+      expect(search.invalid_blocks.join).to eq(<<~'EOM'.indent(2))
         end # one
       EOM
     end
 
     it "returns when no invalid blocks are found" do
-      search = CodeSearch.new(<<~EOM)
+      search = CodeSearch.new(<<~'EOM')
         def foo
           puts 'lol'
         end
@@ -431,14 +439,14 @@ module DeadEnd
     end
 
     it "expands frontier by eliminating valid lines" do
-      search = CodeSearch.new(<<~EOM)
+      search = CodeSearch.new(<<~'EOM')
         def foo
           puts 'lol'
         end
       EOM
       search.create_blocks_from_untracked_lines
 
-      expect(search.code_lines.join).to eq(<<~EOM)
+      expect(search.code_lines.join).to eq(<<~'EOM')
         def foo
         end
       EOM


### PR DESCRIPTION


The "capture code context spec" currently depends on code search which can change as the algorithm evolves. This makes development hard since it's unclear when those tests fail if it's because the functionality changed or the search output changed. Also since the existing "capture context" logic is based on quirks of how the code search algorithm works, when the search is improved it may need different "capture context" logic before it produces good output.

For these cases, we actually need to duplicate the tests 3 times.

- Integration with everything
- Capture Code Context works with static input
- CodeSearch produces the static input we expect

So when all 3 start failing then we can look at it in isolation and see if it "makes sense". I.e. if the CodeSearch output actually "improved" but the integration and capture context are failing then we need to write new logic.