### PR TITLE
Fix default gem require error

### DIFF
--- a/dead_end.gemspec
+++ b/dead_end.gemspec
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-require_relative "lib/dead_end/version"
+begin
+  require_relative "lib/dead_end/version"
+rescue LoadError # Fallback to load version file in ruby core repository
+  require_relative "version"
+end
 
 Gem::Specification.new do |spec|
   spec.name = "dead_end"


### PR DESCRIPTION
When vendoring a default gem in the Ruby repository it uses a different path structure:

```
$ tool/sync_default_gems.rb dead_end
Sync zombocom/dead_end 
```

This causes an error in the gemspec when trying to require a relative file. To overcome this error, other default gems will try to require the expected location and then fallback to a different path such as https://github.com/ruby/error_highlight/blob/f88b6fab2ff34559a0f08d019d574dbb52426a20/error_highlight.gemspec#L4-L8