### PR TITLE
Lazyload DeadEnd internals on syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- [Breaking] Lazy load DeadEnd internals only if there is a Syntax error. Use `require "dead_end"; require "dead_end/api"` to load eagerly all internals. Otherwise `require "dead_end"` will set up an autoload for the first time the DeadEnd module is used in code. This should only happen on a syntax error. (https://github.com/zombocom/dead_end/pull/142)
 - Monkeypatch `SyntaxError#detailed_message` in Ruby 3.2+ instead of `require`, `load`, and `require_relative` (https://github.com/zombocom/dead_end/pull/139)
 
 ## 3.1.2

--- a/dead_end.gemspec
+++ b/dead_end.gemspec
@@ -8,7 +8,7 @@ end
 
 Gem::Specification.new do |spec|
   spec.name = "dead_end"
-  spec.version = DeadEnd::VERSION
+  spec.version = UnloadedDeadEnd::VERSION
   spec.authors = ["schneems"]
   spec.email = ["richard.schneeman+foo@gmail.com"]
 

--- a/exe/dead_end
+++ b/exe/dead_end
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require_relative "../lib/dead_end"
+require_relative "../lib/dead_end/api"
 
 DeadEnd::Cli.new(
   argv: ARGV

--- a/lib/dead_end.rb
+++ b/lib/dead_end.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
 
-require_relative "dead_end/api"
 require_relative "dead_end/core_ext"

--- a/lib/dead_end/api.rb
+++ b/lib/dead_end/api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "version"
 
 require "tmpdir"
@@ -7,6 +9,8 @@ require "ripper"
 require "timeout"
 
 module DeadEnd
+  VERSION = UnloadedDeadEnd::VERSION
+
   # Used to indicate a default value that cannot
   # be confused with another input.
   DEFAULT_VALUE = Object.new.freeze

--- a/lib/dead_end/version.rb
+++ b/lib/dead_end/version.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
-module DeadEnd
+# Calling `DeadEnd::VERSION` forces an eager load due to
+# an `autoload` on the `DeadEnd` constant.
+#
+# This is used for gemspec access in tests
+module UnloadedDeadEnd
   VERSION = "3.1.2"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "dead_end"
+require "dead_end/api"
 
 require "benchmark"
 require "tempfile"


### PR DESCRIPTION
Instead of having to load all dead end code on every invocation of Ruby, we can delay requiring the files until they're actually needed (on SyntaxError).

Resolves this comment https://github.com/ruby/ruby/pull/5859#pullrequestreview-976985456

This requirement makes the library a little unusual in that `dead_end/version` no longer defines `DeadEnd::VERSION` but rather a placeholder value in another constant so the gem isn't eagerly loaded when using the project's gemspec in local tests.