### PR TITLE
Fix yjit support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,14 @@ jobs:
       - checkout
       - ruby/install-deps
       - <<: *unit
+  "ruby-3-2-yjit":
+    docker:
+      - image: 'ruby:3.2.0-preview1'
+    steps:
+      - run: echo "export RUBY_YJIT_ENABLE=1" >> $BASH_ENV
+      - checkout
+      - ruby/install-deps
+      - <<: *unit
 
   "lint":
     docker:
@@ -79,4 +87,5 @@ workflows:
       - "ruby-3-0"
       - "ruby-3-1"
       - "ruby-3-2"
+      - "ruby-3-2-yjit"
       - "lint"

--- a/lib/dead_end/core_ext.rb
+++ b/lib/dead_end/core_ext.rb
@@ -45,7 +45,8 @@ if SyntaxError.new.respond_to?(:detailed_message)
         $stderr.warn(e.backtrace)
       end
 
-      raise e
+      # Ignore internal errors
+      message
     end
   }
 else


### PR DESCRIPTION
For some reason yjit tests on ruby/ruby are failing against the current code:

```
$ time RUBY_YJIT_ENABLE=1 RUBY_TESTOPS="-q --tty=no" make -s check RUN_OPTS=""
# ...
# Fails
```

While this works without yjit enabled it seems the problem is related to an error happening within the `SyntaxError#detailed_message`. It also seems that the other part of the equation is `autoload` with a gem on disk (instead of something in the stdlib). 

One immediate fix is to ensure that if there are any internal errors, that the original syntax error always takes precedent. I've tried to reproduce the failure removing dead_end but I'm unable to, so I want to move ahead. If we find dead_end does not work with YJIT in cases in the future then the YJIT team (and I) can investigate.