### PR TITLE
Respect SyntaxError#detailed_message `highlight` kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## HEAD (unreleased)
 
+- Enable/Disable dead_end by using the `dead_end` kwarg in `detailed_message` (https://github.com/zombocom/dead_end/pull/147)
+- Respect `highlight` kwarg in Ruby 3.2's `detailed_message` to enable/disable control characters (https://github.com/zombocom/dead_end/pull/147)
+
 ## 4.0.0
 
 - Code that does not have an associated file (eval and streamed) no longer produce a warning saying that the file could not be found. To produce a warning with these code types run with DEBUG=1 environment variable. (https://github.com/zombocom/dead_end/pull/143)

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -58,5 +58,26 @@ module DeadEnd
         expect(e).to eq(fake_error)
       }
     end
+
+    it "respects highlight API" do
+      skip if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2")
+
+      error = SyntaxError.new("#{fixtures_dir.join("this_project_extra_def.rb.txt")}:1 ")
+
+      require "dead_end/core_ext"
+
+      expect(error.detailed_message(highlight: true)).to include(DeadEnd::DisplayCodeWithLineNumbers::TERMINAL_HIGHLIGHT)
+      expect(error.detailed_message(highlight: false)).to_not include(DeadEnd::DisplayCodeWithLineNumbers::TERMINAL_HIGHLIGHT)
+    end
+
+    it "can be disabled via falsey kwarg" do
+      skip if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2")
+
+      error = SyntaxError.new("#{fixtures_dir.join("this_project_extra_def.rb.txt")}:1 ")
+
+      require "dead_end/core_ext"
+
+      expect(error.detailed_message(dead_end: true)).to_not eq(error.detailed_message(dead_end: false))
+    end
   end
 end


### PR DESCRIPTION
The kwarg `highlight` is intended to enable/disable control characters https://twitter.com/schneems/status/1532693550474924032. This change brings DeadEnd into alignment with error_highlight with the ability to turn on/off the control characters at will.

One downside of this implementation is that for the case where highlighting is enabled I'm calling super twice. This might have performance implications if someone else is overwriting SyntaxError and doing something possibly expensive (much like DeadEnd is doing).

Alternatively we could try to detect or strip the control code. This would be harder and possibly error prone.

Also addresses:

- Disable/enable dead end based on kwarg https://github.com/ruby/ruby/pull/5516/files#diff-f2e6c18de8171e389aeff0b8d25b2755253108a59a13baf7167c2ffa0af36a58R1388-R1390