### PR TITLE
Fix lazy load for default gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- [Breaking] Lazy loading moved from `autoload` to manually checking for constants and requiring `dead_end/api`. To manually use any DeadEnd internals you MUST require `dead_end/api`, otherwise it will be lazy loaded on syntax error (https://github.com/zombocom/dead_end/pull/148)
 - Default to highlighted output on Ruby 3.2 (https://github.com/zombocom/dead_end/pull/150)
 - Debug functionality enabled by `DEBUG=1` env var is now under `DEAD_END_DEBUG=1`. Note this is not a stable interface or feature. Output content is subject to change without major version change (https://github.com/zombocom/dead_end/pull/149)
 - Enable/Disable dead_end by using the `dead_end` kwarg in `detailed_message` (https://github.com/zombocom/dead_end/pull/147)

--- a/dead_end.gemspec
+++ b/dead_end.gemspec
@@ -8,7 +8,7 @@ end
 
 Gem::Specification.new do |spec|
   spec.name = "dead_end"
-  spec.version = UnloadedDeadEnd::VERSION
+  spec.version = DeadEnd::VERSION
   spec.authors = ["schneems"]
   spec.email = ["richard.schneeman+foo@gmail.com"]
 

--- a/lib/dead_end/api.rb
+++ b/lib/dead_end/api.rb
@@ -9,8 +9,6 @@ require "ripper"
 require "timeout"
 
 module DeadEnd
-  VERSION = UnloadedDeadEnd::VERSION
-
   # Used to indicate a default value that cannot
   # be confused with another input.
   DEFAULT_VALUE = Object.new.freeze

--- a/lib/dead_end/version.rb
+++ b/lib/dead_end/version.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-# Calling `DeadEnd::VERSION` forces an eager load due to
-# an `autoload` on the `DeadEnd` constant.
-#
-# This is used for gemspec access in tests
-module UnloadedDeadEnd
+module DeadEnd
   VERSION = "4.0.0"
 end

--- a/spec/integration/ruby_command_line_spec.rb
+++ b/spec/integration/ruby_command_line_spec.rb
@@ -110,28 +110,10 @@ module DeadEnd
           class Dog
           end
 
-          # When a constant is defined through an autoload
-          # then Object.autoload? will return the name of the
-          # require only until it has been loaded.
-          #
-          # We can use this to detect if DeadEnd internals
-          # have been fully loaded yet or not.
-          #
-          # Example:
-          #
-          #   Object.autoload?("Cat") # => nil
-          #   autoload :Cat, "animals/cat
-          #   Object.autoload?("Cat") # => "animals/cat
-          #   Object.autoload?("Cat") # => "animals/cat
-          #
-          #   # Once required, `autoload?` returns falsey
-          #   puts Cat.meow # invoke autoload
-          #   Object.autoload?("Cat") # => nil
-          #
-          if Object.autoload?("DeadEnd")
-            puts "DeadEnd is NOT loaded"
-          else
+          if defined?(DeadEnd::DEFAULT_VALUE)
             puts "DeadEnd is loaded"
+          else
+            puts "DeadEnd is NOT loaded"
           end
         EOM
 


### PR DESCRIPTION
As pointed out in https://github.com/ruby/ruby/pull/5859#pullrequestreview-994422579 the DeadEnd constant will already be loaded when used as a default gem.

This change moves lazy loading from `autoload` into manually requiring the `dead_end/api` right before we need it. This breaks the API I defined in 4.0 that said we would autoload based on DeadEnd constant access, while I extremely doubt anyone is dependent on that yet it's not hard to rev another major version. I want to be clear and cautious about breaking changes. 

This is a nice change in that the tests got a little simpler and I'm not doing anything strange like having to define an Unloaded constant to not trigger the autoload. An alternative would be to introduce a `DeadEnd::Api` and only have two methods on it `call` and `handle_error`. That might be a little less surprising that to access these features of DeadEnd::Api that you need to load `dead_end/api` however it would be a fairly large refactoring for marginal aesthetic and UX gains.